### PR TITLE
Implement ipaddress_main fact in pure Ruby

### DIFF
--- a/lib/facter/ipaddress_main.rb
+++ b/lib/facter/ipaddress_main.rb
@@ -6,7 +6,7 @@ Facter.add('ipaddress_main') do
   setcode do
     fqdn = Facter.value(:fqdn)
     resolv = Resolv::DNS.new
-    resolv.getaddress(fqdn)
+    resolv.getaddress(fqdn).to_s
   end
 end
 

--- a/lib/facter/ipaddress_main.rb
+++ b/lib/facter/ipaddress_main.rb
@@ -1,9 +1,13 @@
 #!/usr/bin/ruby
 
+require 'resolv'
+
 Facter.add('ipaddress_main') do
   setcode do
     fqdn = Facter.value(:fqdn)
-    %x{dig +short -t A #{fqdn} | grep -E '^[0-9.]+$'}.chomp
+    resolv = Resolv::DNS.new
+    resolv.getaddress(fqdn)
   end
 end
+
 # EOF


### PR DESCRIPTION
Had to do this to avoid a bootstrap issue and it should be more robust this way. However, takes this as a suggestion if you're unsure whether it works for you.